### PR TITLE
[DON'T MERGE] chore: switch from stan to plu-stan

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -6,8 +6,11 @@ packages:
          ./hls-plugin-api
          ./hls-test-utils
 
-
-index-state: 2025-08-08T12:31:54Z
+-- See CONTRIBUTING for some Nix commands you will need to run if you
+-- update either of these.
+index-state:
+  -- Bump both the following dates if you need newer packages from Hackage
+  , hackage.haskell.org 2025-08-08T12:31:54Z
 
 tests: True
 test-show-details: direct
@@ -25,6 +28,15 @@ test-options: -j1
 -- haddock shown on hover
 package *
   ghc-options: -haddock
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/plu-stan
+  --branch: chore/without-custom-extension
+  tag: abd9ab83a56cdafdbba547d693337ce07004e913
+
+
+
 
 constraints:
   -- C++ is hard to distribute, especially on older GHCs

--- a/plugins/hls-stan-plugin/src/Ide/Plugin/Stan.hs
+++ b/plugins/hls-stan-plugin/src/Ide/Plugin/Stan.hs
@@ -23,7 +23,7 @@ import           Ide.Types                   (PluginDescriptor (..), PluginId,
                                               defaultPluginDescriptor)
 import qualified Language.LSP.Protocol.Types as LSP
 import           Stan                        (createCabalExtensionsMap,
-                                              getStanConfig)
+                                              getStanConfig,removeOffchain)
 import           Stan.Analysis               (Analysis (..), runAnalysis)
 import           Stan.Category               (Category (..))
 import           Stan.Cli                    (StanArgs (..))
@@ -157,7 +157,8 @@ rules recorder plId = do
 
               -- A Map from *relative* file paths (just one, in this case) to language extension info:
               cabalExtensionsMap <- liftIO $ createCabalExtensionsMap isLoud (stanArgsCabalFilePath stanArgs) [hieRelative]
-              let analysis = runAnalysis cabalExtensionsMap checksMap ignoredObservations [hieRelative]
+              let analysis' = runAnalysis cabalExtensionsMap checksMap ignoredObservations [hieRelative]
+              analysis <- liftIO $ removeOffchain [hieRelative] analysis'
               return (analysisToDiagnostics file analysis, Just ())
       else return ([], Nothing)
 


### PR DESCRIPTION
usage:

1. `cabal build`

2. the exe can be at found running `cabal list-bin exe:haskell-language-server`

where:
   - POJECT_PATH: is the path to this cloned repo
   - ARCH: computer architecture
         - aarch64-osx
         - x86_64-osx
          - aarch64-linux
         - x86_64-linux
         